### PR TITLE
As well as copying the original file, create thumbnails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gem 'everypoliticianbot', git: 'https://github.com/everypolitician/everypoliticianbot'
 gem 'parallel'
+gem 'pry'
 gem 'rmagick'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'parallel'
 gem 'everypoliticianbot', git: 'https://github.com/everypolitician/everypoliticianbot'
+gem 'rmagick'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'parallel'
 gem 'everypoliticianbot', git: 'https://github.com/everypolitician/everypoliticianbot'
+gem 'parallel'
 gem 'rmagick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     parallel (1.6.1)
+    rmagick (2.16.0)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -27,6 +28,7 @@ PLATFORMS
 DEPENDENCIES
   everypoliticianbot!
   parallel
+  rmagick
 
 BUNDLED WITH
-   1.10.6
+   1.14.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,17 +10,24 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
+    coderay (1.1.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.2.9.1)
+    method_source (0.8.2)
     multipart-post (2.0.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     parallel (1.6.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rmagick (2.16.0)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
@@ -28,6 +35,7 @@ PLATFORMS
 DEPENDENCIES
   everypoliticianbot!
   parallel
+  pry
   rmagick
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ You'll be able to choose a name for your new app. You'll also need to configure 
 - `GITHUB_ACCESS_TOKEN` - A [Personal Access Token](https://github.com/settings/tokens) with permission to push to the `GITHUB_REPO`.
 - `EVERYPOLITICIAN_COUNTRY_SLUG` - The `slug` of the country you want to cache images for. Find slugs [in everypolitician-data's countries.json](https://github.com/everypolitician/everypolitician-data/blob/master/countries.json).
 
+You may want to supplement the images found via EveryPolitician
+with others referenced by CSV files. In that case you can add the
+following optional environment variable too:
+
+- `EXTRA_CSV` - This is a semi-colon separated list of
+  `<DIRECTORY>:<CSV-URL>` specifiers. `<DIRECTORY>` is the name
+  of the directory in the target repository that the images will
+  be put in, and the `<CSV-URL>` should be the URL of a CSV file
+  that at least contains columns headed `id` and
+  `image_url`. For example, you could use: `EXTRA_CSV='Governors:http://example.com/governors.csv;Senate:http://example.com/senate.csv'`
+
 ![screen shot 2015-12-18 at 18 03 03](https://cloud.githubusercontent.com/assets/22996/11903508/ac08685e-a5b1-11e5-891e-9522ab1400c7.png)
 
 After the app has been created go to the Heroku Dashboard, select the newly created app and then click on the "Heroku Scheduler" add-on to get to the Scheduler Dashboard.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ First click this button and follow the setup instructions:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-You'll be able to choose a name for your new app. You'll also need to configure 3 settings:
+You'll be able to choose a name for your new app. You'll also need to configure 4 settings:
 
+- `IMAGE_SIZES` - This is a comma-separated list of the sizes of
+  images you want to be generated. For example, if you want
+  100x100 pixel thumbnails and the original versions, you should
+  use: `IMAGE_SIZES=100x100,original`
 - `GITHUB_REPO` - This should be the name of the repo you want to push the images to, in the form `user_or_org/repo_slug`.
 - `GITHUB_ACCESS_TOKEN` - A [Personal Access Token](https://github.com/settings/tokens) with permission to push to the `GITHUB_REPO`.
 - `EVERYPOLITICIAN_COUNTRY_SLUG` - The `slug` of the country you want to cache images for. Find slugs [in everypolitician-data's countries.json](https://github.com/everypolitician/everypolitician-data/blob/master/countries.json).

--- a/bin/image_cache
+++ b/bin/image_cache
@@ -14,11 +14,29 @@ def parse_image_sizes(sizes)
   end
 end
 
+def parse_extra_csv(extra_csv_files)
+  # Assume that these look like:
+  #  Governors:http://example.com/governors.csv;Senate:http://example.com/senate.csv
+  # i.e. the data for each "house" is separated by a semi-colon, and
+  # each house is represented by the directory name, then a colon,
+  # then the CSV URL.
+  return {} unless extra_csv_files
+  extra_csv_files.split(';').map do |house_data|
+    md = /^(?<dir>.*?):(?<url>.*)$/.match(house_data)
+    md.names.zip(md.captures).to_h
+  end
+end
+
 begin
   country_slug = ENV.fetch('EVERYPOLITICIAN_COUNTRY_SLUG')
   github_repo = ENV.fetch('GITHUB_REPO')
   sizes = ENV.fetch('IMAGE_SIZES')
-  ImageCache.cache!(country_slug, github_repo, parse_image_sizes(sizes))
+  ImageCache.cache!(
+    country_slug,
+    github_repo,
+    parse_extra_csv(ENV['EXTRA_CSV']),
+    parse_image_sizes(sizes)
+  )
 rescue KeyError => e
   abort "Missing required environment variables: #{e}"
 end

--- a/bin/image_cache
+++ b/bin/image_cache
@@ -6,10 +6,19 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'image_cache'
 
+def parse_image_sizes(sizes)
+  sizes.split(',').map do |s|
+    match = /^(original|\d+x\d+)$/.match(s)
+    raise RuntimeError, "Invalid size '#{s}' - it must be 'original' or WIDTHxHEIGHT" unless match
+    match[1]
+  end
+end
+
 begin
   country_slug = ENV.fetch('EVERYPOLITICIAN_COUNTRY_SLUG')
   github_repo = ENV.fetch('GITHUB_REPO')
-  ImageCache.cache!(country_slug, github_repo)
+  sizes = ENV.fetch('IMAGE_SIZES')
+  ImageCache.cache!(country_slug, github_repo, parse_image_sizes(sizes))
 rescue KeyError => e
   abort "Missing required environment variables: #{e}"
 end

--- a/lib/image_cache.rb
+++ b/lib/image_cache.rb
@@ -2,8 +2,8 @@ require 'image_cache/cacher'
 require 'image_cache/countries'
 
 module ImageCache
-  def self.cache!(country_slug, github_repo)
+  def self.cache!(country_slug, github_repo, sizes)
     country = Countries.new.country(country_slug)
-    Cacher.new(country, github_repo).cache!
+    Cacher.new(country, github_repo, sizes).cache!
   end
 end

--- a/lib/image_cache.rb
+++ b/lib/image_cache.rb
@@ -2,8 +2,8 @@ require 'image_cache/cacher'
 require 'image_cache/countries'
 
 module ImageCache
-  def self.cache!(country_slug, github_repo, sizes)
+  def self.cache!(country_slug, github_repo, extra_csv, sizes)
     country = Countries.new.country(country_slug)
-    Cacher.new(country, github_repo, sizes).cache!
+    Cacher.new(country, github_repo, extra_csv, sizes).cache!
   end
 end

--- a/lib/image_cache/cacher.rb
+++ b/lib/image_cache/cacher.rb
@@ -3,6 +3,8 @@ require 'everypoliticianbot'
 require 'fileutils'
 require 'json'
 require 'open-uri'
+require 'tempfile'
+require 'rmagick'
 
 module ImageCache
   class Cacher
@@ -10,10 +12,12 @@ module ImageCache
 
     attr_reader :country
     attr_reader :github_repo
+    attr_reader :sizes
 
-    def initialize(country, github_repo)
+    def initialize(country, github_repo, sizes)
       @country = country
       @github_repo = github_repo
+      @sizes = sizes
     end
 
     def cache!
@@ -28,31 +32,60 @@ module ImageCache
         popolo_url = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/#{legislature[:popolo]}"
         popolo = JSON.parse(open(popolo_url).read, symbolize_names: true)
         directory = legislature[:slug]
+        FileUtils.mkdir_p(directory)
         filelist = Parallel.map(popolo[:persons], in_threads: 3) do |person|
           cache_person(person, directory)
         end
-        FileUtils.mkdir_p(directory)
         index_file = File.join(directory, 'index.txt')
         File.write(index_file, filelist.flatten.compact.sort.join("\n"))
       end
+    end
+
+    def with_downloaded_file(url)
+      contents = open(url, &:read)
+      temporary_file = Tempfile.open('ep-image_cache') do |f|
+        f.write(contents)
+        f
+      end
+      block_result = yield temporary_file.path
+      temporary_file.unlink
+      block_result
+    end
+
+    def resize_image(original_filename, reduced_filename, width, height)
+      img = Magick::Image.read(original_filename).first
+      reduced = img.resize_to_fit!(width, height)
+      reduced.background_color = 'white'
+      img.write(reduced_filename)
     end
 
     def cache_person(person, basedir)
       return if person[:image].to_s.empty?
       person_id = person[:id]
       # TODO: Check if the image is actually a jpeg
-      filepath = File.join(basedir, "#{person_id}.jpeg")
-      FileUtils.mkdir_p(File.dirname(filepath))
-      return person_id if File.exist?(filepath) && !ENV['FORCE_UPDATE']
-      begin
-        contents = open(person[:image]).read
-        return if contents.empty?
-        File.write(filepath, contents)
-        log "Copied #{person[:image]} to #{filepath}"
-        return person_id
-      rescue OpenURI::HTTPError => e
-        err "Error trying to cache #{person[:image]}: #{e}"
-        return
+      person_directory = File.join(basedir, person_id)
+      FileUtils.mkdir_p(person_directory)
+      with_downloaded_file(person[:image]) do |local_filename|
+        sizes.map do |size|
+          relative_filepath = File.join(person_id, "#{size}.jpeg")
+          filepath = File.join(basedir, relative_filepath)
+          next relative_filepath if File.exist?(filepath) && !ENV['FORCE_UPDATE']
+          begin
+            if size == 'original'
+              FileUtils.cp(local_filename, filepath)
+              log "Copied #{person[:image]} to #{filepath}"
+            else
+              width, height = size.match(/(\d+)x(\d+)/).captures
+              width, height = Integer(width), Integer(height)
+              resize_image(local_filename, filepath, width, height)
+              log "Resized #{person[:image]} to #{filepath}"
+            end
+          rescue OpenURI::HTTPError => e
+            err "Error trying to cache #{person[:image]}: #{e}"
+            next
+          end
+          relative_filepath
+        end
       end
     end
 

--- a/lib/image_cache/cacher.rb
+++ b/lib/image_cache/cacher.rb
@@ -1,3 +1,4 @@
+require 'csv'
 require 'parallel'
 require 'everypoliticianbot'
 require 'fileutils'
@@ -12,12 +13,38 @@ module ImageCache
 
     attr_reader :country
     attr_reader :github_repo
+    attr_reader :extra_csv
     attr_reader :sizes
 
-    def initialize(country, github_repo, sizes)
+    def initialize(country, github_repo, extra_csv, sizes)
       @country = country
       @github_repo = github_repo
+      @extra_csv = extra_csv
       @sizes = sizes
+    end
+
+    def extract_from_ep(legislature)
+      # Return a two element array where the first element is the
+      # directory for the images, and the second is an array of hashes
+      # where each hash corresponds to a person.
+      popolo_url = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/#{legislature[:popolo]}"
+      popolo = JSON.parse(open(popolo_url).read, symbolize_names: true)
+      [legislature[:slug], popolo[:persons]]
+    end
+
+    def extract_from_csv(csv_metadata)
+      # Return a two element array where the first element is the
+      # directory for the images, and the second is an array of hashes
+      # where each hash corresponds to a person.
+      [
+        csv_metadata['dir'],
+        CSV.parse(open(csv_metadata['url']), :headers => :first_line).map do |row|
+          {
+            :id => row['id'],
+            :image => row['image_url']
+          }
+        end
+      ]
     end
 
     def cache!
@@ -27,13 +54,20 @@ module ImageCache
       end
     end
 
+    def house_to_people
+      (
+        country[:legislatures].map do |legislature|
+          extract_from_ep(legislature)
+        end + extra_csv.map do |csv_metadata|
+          extract_from_csv(csv_metadata)
+        end
+      ).to_h
+    end
+
     def cache_country(country)
-      country[:legislatures].each do |legislature|
-        popolo_url = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/#{legislature[:popolo]}"
-        popolo = JSON.parse(open(popolo_url).read, symbolize_names: true)
-        directory = legislature[:slug]
+      house_to_people.map do |directory, people|
         FileUtils.mkdir_p(directory)
-        filelist = Parallel.map(popolo[:persons], in_threads: 3) do |person|
+        filelist = Parallel.map(people, in_threads: 3) do |person|
           cache_person(person, directory)
         end
         index_file = File.join(directory, 'index.txt')


### PR DESCRIPTION
[n.b. I haven't thought much about whether this actually should
be merged or not - the PR is largely so we don't lose track of
this. In other words, there's no urgency to review this, and it's
probably not very high quality - I made the changes quite
quickly.]

You can specify the sizes to generate with the IMAGE_SIZES
environment variable, e.g.

  EVERYPOLITICIAN_COUNTRY_SLUG=Nigeria \
     GITHUB_REPO=theyworkforyou/shineyoureye-images \
     IMAGE_SIZES=original,250x250,100x100 \
     bundle exec bin/image_cache

... would generate files in the shineyoureye-images repository of the
form:

  Senate/5744450e-41b7-4d7d-b81a-83f42f34437d/100x100.jpeg
  Senate/5744450e-41b7-4d7d-b81a-83f42f34437d/250x250.jpeg
  Senate/5744450e-41b7-4d7d-b81a-83f42f34437d/original.jpeg
  Senate/129b69f6-8a86-4407-9525-8a2f8caa5828/100x100.jpeg
  Senate/129b69f6-8a86-4407-9525-8a2f8caa5828/250x250.jpeg
  Senate/129b69f6-8a86-4407-9525-8a2f8caa5828/original.jpeg